### PR TITLE
Suppress cuke warnings

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -5,6 +5,7 @@ require File.expand_path('../boot', __FILE__)
 require 'rails/all'
 require 'sass'
 require 'coffee_script'
+require 'tilt/coffee'
 
 Bundler.require(*Rails.groups)
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -5,7 +5,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "support", "sel
 ならば /^"([^"]*)"ページにリダイレクトすること$/ do |page_name|
   path = URI.parse(current_url).path
   begin
-    timeout(Capybara.default_wait_time) do
+    Timeout.timeout(Capybara.default_wait_time) do
       while(path != path_to(page_name)) do
         sleep 0.1
         path = URI.parse(current_url).path

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -5,7 +5,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "support", "sel
 ならば /^"([^"]*)"ページにリダイレクトすること$/ do |page_name|
   path = URI.parse(current_url).path
   begin
-    Timeout.timeout(Capybara.default_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time) do
       while(path != path_to(page_name)) do
         sleep 0.1
         path = URI.parse(current_url).path

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -107,9 +107,9 @@ Before do
 end
 
 if ENV['TRAVIS']
-  Capybara.default_wait_time = 60
+  Capybara.default_max_wait_time = 60
 else
-  Capybara.default_wait_time = 5
+  Capybara.default_max_wait_time = 5
 end
 
 Capybara::Webkit.configure do |config|
@@ -122,7 +122,7 @@ end
 # http://qiita.com/kntmrkm/items/a02f5694843fee97763e
 module WaitForAjax
   def wait_for_ajax
-    Timeout.timeout(Capybara.default_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time) do
       loop until finished_all_ajax_requests?
     end
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -112,6 +112,11 @@ else
   Capybara.default_wait_time = 5
 end
 
+Capybara::Webkit.configure do |config|
+  config.allow_url("ghbtns.com")
+  config.allow_url("api.github.com")
+  config.allow_url("s3.amazonaws.com")
+end
 
 # https://gist.github.com/josevalim/470808
 # http://qiita.com/kntmrkm/items/a02f5694843fee97763e


### PR DESCRIPTION
- external URL access
- deprecated Object#timeout usage
- Capybara::default_wait_time is deprecated
- autoloading tilt/coffee loading is not thread-safe
