### PR TITLE
Exec apt-get update before install

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,6 +15,7 @@ jobs:
         ruby-version: 2.5.x
     - name: Install required packages to build/test
       run: |
+        sudo apt-get update
         sudo apt-get install -y libqtwebkit-dev libqtwebkit4 libmysqlclient-dev libpq-dev libsqlite3-dev nodejs xvfb
     - name: Install bundler and install required gems
       run: |


### PR DESCRIPTION
Sometimes apt-get install is in fail because apt's cache is too old in GH Actions.